### PR TITLE
Fix to try and resolve module version mismatch on Mac.

### DIFF
--- a/tools/install.js
+++ b/tools/install.js
@@ -71,5 +71,64 @@ if (process.platform === 'win32') {
 } 
 
 else {
-	spawn('node-gyp', ['configure', 'build'], { stdio: 'inherit' });
+	if (process.platform === 'darwin') {
+
+		// Code from electron-prebuild: https://github.com/electron/electron-rebuild
+		const possibleModuleNames = ['electron', 'electron-prebuilt', 'electron-prebuilt-compile'];
+
+		function locateElectronPrebuilt () {
+			let electronPath;
+
+			// Attempt to locate modules by path
+			let foundModule = possibleModuleNames.some((moduleName) => {
+				electronPath = path.join(__dirname, '..', '..', moduleName);
+				return fs.existsSync(electronPath);
+			});
+
+			// Return a path if we found one
+			if (foundModule) return electronPath;
+
+			// Attempt to locate modules by require
+			foundModule = possibleModuleNames.some((moduleName) => {
+				try {
+				electronPath = path.join(require.resolve(moduleName), '..');
+				} catch (e) {
+				return false;
+				}
+				return fs.existsSync(electronPath);
+			});
+
+			// Return a path if we found one
+			if (foundModule) return electronPath;
+			return null;
+		}
+
+		location = locateElectronPrebuilt();
+		version = null;
+		electronPath = null;
+		if (location != null)
+		{ 
+			// NB: We assume here that electron-prebuilt is a sibling package of ours
+			pkg = null;
+			try {
+				let pkgJson = path.join(location, 'package.json');
+
+				pkg = require(pkgJson);
+
+				version = pkg.version;
+			} catch (e) {
+				console.error("Unable to find electron-prebuilt's version number, either install it or specify an explicit version");
+			}
+		}
+		if (version !== null)
+		{
+			spawn('node-gyp', ['configure', 'build', '--target='+version, '--disturl=https://atom.io/download/atom-shell'], { stdio: 'inherit' });
+		}
+		else
+			spawn('node-gyp', ['configure', 'build'], { stdio: 'inherit' });
+   		
+	}
+	else {
+		spawn('node-gyp', ['configure', 'build'], { stdio: 'inherit' });
+	}
 }


### PR DESCRIPTION
https://github.com/kexplo/electron-edge/issues/18

A JavaScript error occurred in the main process
Error: Module version mismatch. Expected XX, got YY.
    at Error (native)
    at process.module.(anonymous function) [as dlopen](ELECTRON_ASAR.js:168:20)
    at Object.Module._extensions..node (module.js:583:18)
    at Object.module.(anonymous function) [as .node](ELECTRON_ASAR.js:168:20)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.require (module.js:483:17)
    at require (internal/module.js:20:19)
- When executing the install script this will try to work out the version of electron that is installed and when executing the node-gyp on Mac will pass the --target=version to the build build process.
- This only affects the Mac installation as I do not have a Linux to test with.
- Without this change one would have rebuild the Native Modules as outlined in issue https://github.com/kexplo/electron-edge/issues/18
- Since this tries to resolve electron this seemed to be the best place for the change instead of in the Edge project.
