### PR TITLE
Requires strict mode for the `let` option

### DIFF
--- a/tools/install.js
+++ b/tools/install.js
@@ -1,3 +1,4 @@
+"use strict"
 var fs = require('fs')
 	, path = require('path')
 	, spawn = require('child_process').spawn


### PR DESCRIPTION
Ran into this when using npm rebuild in a project. So here is the fix.